### PR TITLE
Added a new branch to demostrate mw_malloc2d for 4.1repl_class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ EMU_OBJS = $(subst .cc,.emu.o,$(SRCS))
 #EMU_PATH = /local/devel/packages/emu-18.11-cplus
 #EMU_PATH = /local/devel/packages/emu-19.02
 EMU_PATH = /home/jgwohlbier/devel/packages/emu-19.02
+#EMU_PATH = /usr/local/emu-19.02
 EMU_CXX = $(EMU_PATH)/bin/emu-cc
 EMU_SIM = $(EMU_PATH)/bin/emusim.x
 
@@ -18,6 +19,9 @@ EMU_EXE = $(EXE).mwx
 
 LDFLAGS = -lemu_c_utils
 
+#CPPFLAGS += -Dtimeit
+
+
 $(EMU_EXE) : $(EMU_OBJS)
 	$(EMU_CXX) -o $(EMU_EXE) $(EMU_OBJS) $(LDFLAGS)
 
@@ -25,6 +29,7 @@ run : $(EMU_EXE)
 	$(EMU_SIM) $(EMU_SIM_OPTS) $(EMU_EXE)
 
 profile : $(EMU_EXE)
+ 	#EMU_CDC_DIFF=1 \ 
 	$(EMU_PROFILE) profile $(EMU_SIM_ARGS) -- $(EMU_EXE)
 
 %.emu.o: %.cc

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ EMU_OBJS = $(subst .cc,.emu.o,$(SRCS))
 #EMU_PATH = /local/devel/packages/emu-18.11-cplus
 #EMU_PATH = /local/devel/packages/emu-19.02
 EMU_PATH = /home/jgwohlbier/devel/packages/emu-19.02
-#EMU_PATH = /usr/local/emu-19.02
 EMU_CXX = $(EMU_PATH)/bin/emu-cc
 EMU_SIM = $(EMU_PATH)/bin/emusim.x
 
@@ -19,9 +18,6 @@ EMU_EXE = $(EXE).mwx
 
 LDFLAGS = -lemu_c_utils
 
-#CPPFLAGS += -Dtimeit
-
-
 $(EMU_EXE) : $(EMU_OBJS)
 	$(EMU_CXX) -o $(EMU_EXE) $(EMU_OBJS) $(LDFLAGS)
 
@@ -29,7 +25,6 @@ run : $(EMU_EXE)
 	$(EMU_SIM) $(EMU_SIM_OPTS) $(EMU_EXE)
 
 profile : $(EMU_EXE)
- 	#EMU_CDC_DIFF=1 \ 
 	$(EMU_PROFILE) profile $(EMU_SIM_ARGS) -- $(EMU_EXE)
 
 %.emu.o: %.cc


### PR DESCRIPTION
In continuation to bug https://github.com/emusolutions/emu-issue-tracking/issues/60

Eric's suggestion is to have 1 thread per nodelet. So we will be always limited by just 8 threads for 8 nodelets. By default, there are only 8 nodelets in the simulator for single node configuration.